### PR TITLE
💼 Grab bag: Handle 1000+ emoji, other improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "react-dom": "^0.14.0",
     "react-dropzone": "^2.1.0",
     "strip": "0.0.7",
-    "superagent": "^1.4.0",
-    "uuid": "^2.0.1"
+    "superagent": "^1.4.0"
   },
   "browserify": {
     "debug": true,

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "watchify": "^3.4.0"
   },
   "dependencies": {
+    "bottleneck": "^1.15.0",
     "classnames": "^2.1.5",
     "lodash": "^3.10.1",
     "react": "^0.14.0",

--- a/src/components/Uploader.jsx
+++ b/src/components/Uploader.jsx
@@ -2,9 +2,10 @@ import React from 'react';
 import Dropzone from 'react-dropzone';
 import cx from 'classnames';
 import findIndex from 'lodash/array/findIndex';
-import uuid from 'uuid';
 
 import { uploadEmoji } from '../services/upload.js';
+
+let nextId = 0;
 
 var Uploader = React.createClass({
   getInitialState: function () {
@@ -15,7 +16,7 @@ var Uploader = React.createClass({
   handleDrop: function (files) {
     const queue = files.map(file => {
       return {
-        id: uuid.v4(),
+        id: nextId++,
         file,
         success: null,
         error: null

--- a/src/components/Uploader.jsx
+++ b/src/components/Uploader.jsx
@@ -60,7 +60,7 @@ var Uploader = React.createClass({
           <img className="set__uploader__upload__preview" src={upload.file.preview} />
           <span className="set__uploader__upload__filename">{upload.file.name}</span>
           <span className="set__uploader__upload__status">
-            <i className="set__uploader__upload__status__icon set__uploader__upload__status__icon-uploading ts_icon ts_icon_spinner" />
+            <i className="set__uploader__upload__status__icon set__uploader__upload__status__icon-uploading ts_icon ts_icon_spin ts_icon_spinner" />
             <i className="set__uploader__upload__status__icon set__uploader__upload__status__icon-error ts_icon ts_icon_warning" />
             <i className="set__uploader__upload__status__icon set__uploader__upload__status__icon-success ts_icon ts_icon_check_circle_o" />
             {status}

--- a/src/services/upload.js
+++ b/src/services/upload.js
@@ -1,9 +1,10 @@
+import Bottleneck from 'bottleneck'
 import superagent from 'superagent';
 import each from 'lodash/collection/each';
 import strip from 'strip';
-import uuid from 'uuid';
 
 const NO_OP = function () {};
+const limiter = new Bottleneck(3, 75);
 
 var upload_service = {
   _getHiddenFormData: function () {
@@ -22,8 +23,10 @@ var upload_service = {
     return error_text;
   },
   uploadEmoji: function (file, callback = NO_OP) {
+    limiter.submit(upload_service._uploadEmoji, file, callback);
+  },
+  _uploadEmoji: function (file, callback = NO_OP) {
     var hidden_form_data = upload_service._getHiddenFormData();
-    var id = uuid.v4();
     var name = file.name.split('.')[0];
     var image_upload_request = superagent.post('/customize/emoji')
       .withCredentials()
@@ -37,7 +40,6 @@ var upload_service = {
       var response_error = upload_service._extractError(response.text);
       callback(response_error, response);
     });
-    return id;
   }
 };
 

--- a/src/services/upload.js
+++ b/src/services/upload.js
@@ -37,7 +37,10 @@ var upload_service = {
       image_upload_request.field(name, value)
     });
     image_upload_request.end((error, response) => {
-      var response_error = upload_service._extractError(response.text);
+      const response_error = error
+        ? `HTTP ${error.status}`
+        : upload_service._extractError(response.text);
+
       callback(response_error, response);
     });
   }


### PR DESCRIPTION
Hi - thanks for this Chrome extension! ❤

I tried to upload 1100 emoji at once with it but Slack’s servers got sad and returned many 504s.

So here are some improvements!

After adding `bottleneck` I discovered the existence of `superagent-throttle`. Unfortunately, it’s got a dependency on superagent 1.x (the package is now at 3.x), so I didn’t think it’d be worth trying to convert to.

I think there was a race condition of sorts before, that probably only popped up when trying to upload tons of emoji at once. Since the React setStates are likely asynchronous, I believe the setState calls in the completion handler could clobber one another, resulting in some of the uploads never appearing to finish. So I came up with another method, which turned out also to allow removing `uuid`.